### PR TITLE
add missing state_class to 4-10um pm sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -300,6 +300,7 @@ sensor:
     disabled_by_default: true
     lambda: return id(pm_10_0).state - id(pm_4_0).state;
     unit_of_measurement: "µg/m³"
+    state_class: measurement
     icon: mdi:air-filter
     update_interval: 10s
 


### PR DESCRIPTION
the custom sensor for pm 4-10um is missing `state_class`, therefore home assistant will not store history+statistics for it. This PR adds it to align with the other 3 sibling sensors

Bug is present in main branch and in factory v24.10.11.1

Version not updated in core.yaml as this appears to be a private versioning scheme